### PR TITLE
Ellis -- Hide select role buttons until user is loaded and test SelectRoleActivity

### DIFF
--- a/LuckyDragon/.idea/deploymentTargetSelector.xml
+++ b/LuckyDragon/.idea/deploymentTargetSelector.xml
@@ -5,6 +5,9 @@
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
+      <SelectionState runConfigName="Tests in 'com.example.luckydragon'">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/LuckyDragon/app/src/androidTest/java/com/example/luckydragon/SelectRoleActivityTest.java
+++ b/LuckyDragon/app/src/androidTest/java/com/example/luckydragon/SelectRoleActivityTest.java
@@ -19,6 +19,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static org.hamcrest.CoreMatchers.not;
 
 import android.content.Context;
+import android.util.Log;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
@@ -36,7 +37,6 @@ import org.junit.Test;
 @RunWith(AndroidJUnit4.class)
 @LargeTest
 public class SelectRoleActivityTest {
-
     /**
      * TEST
      * Tests that only "Entrant" and "Organizer" buttons show for a user without admin privileges.
@@ -50,6 +50,7 @@ public class SelectRoleActivityTest {
         // Set user to a test object
         GlobalApp globalApp = (GlobalApp) targetContext.getApplicationContext();
         User testUser = new User("test");
+        testUser.setIsLoaded(true);
         globalApp.setUser(testUser);
 
         try(final ActivityScenario<SelectRoleActivity> scenario = ActivityScenario.launch(intent)) {
@@ -78,6 +79,7 @@ public class SelectRoleActivityTest {
         GlobalApp globalApp = (GlobalApp) targetContext.getApplicationContext();
         User testUser = new User("test");
         testUser.setAdmin(true);
+        testUser.setIsLoaded(true);
         globalApp.setUser(testUser);
 
         try(final ActivityScenario<SelectRoleActivity> scenario = ActivityScenario.launch(intent)) {

--- a/LuckyDragon/app/src/androidTest/java/com/example/luckydragon/SelectRoleActivityTest.java
+++ b/LuckyDragon/app/src/androidTest/java/com/example/luckydragon/SelectRoleActivityTest.java
@@ -1,4 +1,15 @@
+/**
+ * Contains tests for SelectRoleActivity.
+ */
+
 package com.example.luckydragon;
+
+import android.content.Intent;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.filters.LargeTest;
+
+import org.junit.runner.RunWith;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
@@ -8,20 +19,20 @@ import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static org.hamcrest.CoreMatchers.not;
 
 import android.content.Context;
-import android.content.Intent;
-
-import androidx.test.core.app.ActivityScenario;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.filters.LargeTest;
 import androidx.test.platform.app.InstrumentationRegistry;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
-import java.util.HashMap;
-import java.util.Map;
-
+/**
+ * This is a test class for SelectRoleActivity.
+ * It tests that the correct role buttons show for a user depending on whether they have admin privileges or not.
+ * NOTES:
+ *   - The User is set in GlobalApp before the activity is started, so no database fetching will occur in these tests.
+ *   - Use the ActivityScenario.launch() syntax to run some code before the activity starts. ActivityScenarioRule does not allow this.
+ *   - We need to call notifyObservers() on the test user to update the views to reflect the user. This must be done on the UI thread, or an error will occur.
+ */
 @RunWith(AndroidJUnit4.class)
 @LargeTest
 public class SelectRoleActivityTest {
@@ -36,44 +47,49 @@ public class SelectRoleActivityTest {
         final Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
         final Intent intent = new Intent(targetContext, SelectRoleActivity.class);
 
-        Map<String, Object> mockUserData = new HashMap<>();
-        mockUserData.put("isAdmin", false);
-
-        /*
-         * Note that the observable for the mock controller is set to 'null' here.
-         * It will be set to the correct observable within SelectRoleActivity.
-         * This is done because we don't have access to the Observable here until the activity is started below (which is too late)
-         */
-        MockSelectRoleController mockSelectRoleController = new MockSelectRoleController(null, mockUserData);
-        intent.putExtra("controller", mockSelectRoleController);
+        // Set user to a test object
+        GlobalApp globalApp = (GlobalApp) targetContext.getApplicationContext();
+        User testUser = new User("test");
+        globalApp.setUser(testUser);
 
         try(final ActivityScenario<SelectRoleActivity> scenario = ActivityScenario.launch(intent)) {
+            // Update views to match testUser (this must run on ui thread -- error otherwise)
+            scenario.onActivity(a -> {
+                a.runOnUiThread(testUser::notifyObservers);
+            });
+
+            // Assertions
             onView(withId(R.id.entrantButton)).check(matches(isDisplayed()));
             onView(withId(R.id.organizerButton)).check(matches(isDisplayed()));
             onView(withId(R.id.adminButton)).check(matches(not(isDisplayed())));
         }
     }
 
-    @Test
     /**
      * TEST
-     * Tests that only "Entrant" and "Organizer" buttons show for a user without admin privileges.
-     * "Administrator" button should not be visible.
+     * Tests that "Entrant", "Organizer", and "Administrator" buttons show for a user with admin privileges.
      */
+    @Test
     public void testButtonsForAdminUser() {
         final Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
         final Intent intent = new Intent(targetContext, SelectRoleActivity.class);
 
-        Map<String, Object> mockUserData = new HashMap<>();
-        mockUserData.put("isAdmin", true);
-
-        MockSelectRoleController mockSelectRoleController = new MockSelectRoleController(null, mockUserData);
-        intent.putExtra("controller", mockSelectRoleController);
+        // Set user to a test object
+        GlobalApp globalApp = (GlobalApp) targetContext.getApplicationContext();
+        User testUser = new User("test");
+        testUser.setAdmin(true);
+        globalApp.setUser(testUser);
 
         try(final ActivityScenario<SelectRoleActivity> scenario = ActivityScenario.launch(intent)) {
+            // Update views to match testUser (this must run on ui thread -- error otherwise)
+            scenario.onActivity(a -> {
+                a.runOnUiThread(testUser::notifyObservers);
+            });
+
+            // Assertions
             onView(withId(R.id.entrantButton)).check(matches(isDisplayed()));
             onView(withId(R.id.organizerButton)).check(matches(isDisplayed()));
-            onView(withId(R.id.adminButton)).check(matches(isDisplayed()));
+            onView(withId(R.id.adminButton)).check(matches((isDisplayed())));
         }
     }
 }

--- a/LuckyDragon/app/src/androidTest/java/com/example/luckydragon/SelectRoleActivityTest.java
+++ b/LuckyDragon/app/src/androidTest/java/com/example/luckydragon/SelectRoleActivityTest.java
@@ -91,7 +91,7 @@ public class SelectRoleActivityTest {
             // Assertions
             onView(withId(R.id.entrantButton)).check(matches(isDisplayed()));
             onView(withId(R.id.organizerButton)).check(matches(isDisplayed()));
-            onView(withId(R.id.adminButton)).check(matches((isDisplayed())));
+            onView(withId(R.id.adminButton)).check(matches((not(isDisplayed()))));
         }
     }
 }

--- a/LuckyDragon/app/src/androidTest/java/com/example/luckydragon/SelectRoleActivityTest.java
+++ b/LuckyDragon/app/src/androidTest/java/com/example/luckydragon/SelectRoleActivityTest.java
@@ -91,7 +91,7 @@ public class SelectRoleActivityTest {
             // Assertions
             onView(withId(R.id.entrantButton)).check(matches(isDisplayed()));
             onView(withId(R.id.organizerButton)).check(matches(isDisplayed()));
-            onView(withId(R.id.adminButton)).check(matches((not(isDisplayed()))));
+            onView(withId(R.id.adminButton)).check(matches((isDisplayed())));
         }
     }
 }

--- a/LuckyDragon/app/src/main/java/com/example/luckydragon/Event.java
+++ b/LuckyDragon/app/src/main/java/com/example/luckydragon/Event.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  * Issues:
  *   - could add another constructor for when waitlist limit is not specified (since it is optional)
  */
-public class Event implements Serializable {
+public class Event {
     /**
      * Represents a time as hours and minutes in 24 hour time.
      * e.g. 8:30 pm would have hours = 20 and minutes = 30

--- a/LuckyDragon/app/src/main/java/com/example/luckydragon/GlobalApp.java
+++ b/LuckyDragon/app/src/main/java/com/example/luckydragon/GlobalApp.java
@@ -20,4 +20,8 @@ public class GlobalApp extends Application {
         }
         return user;
     }
+
+    public void setUser(User newUser) {
+        user = newUser;
+    }
 }

--- a/LuckyDragon/app/src/main/java/com/example/luckydragon/SelectRoleActivity.java
+++ b/LuckyDragon/app/src/main/java/com/example/luckydragon/SelectRoleActivity.java
@@ -47,11 +47,13 @@ public class SelectRoleActivity extends AppCompatActivity {
     }
 
     public void initializeView() {
+        Log.e("TEST", "starting initialize view");
         // Set content view (don't do this until after user has been fetched from db)
         setContentView(R.layout.select_role_page); // set content to role page
 
         // Set up on entrant click listener
         Button entrantButton = findViewById(R.id.entrantButton);
+        entrantButton.setVisibility(View.VISIBLE);
         if (!entrantButton.hasOnClickListeners()) {
             entrantButton.setOnClickListener(v -> {
                 if (user.isEntrant()) {
@@ -70,6 +72,7 @@ public class SelectRoleActivity extends AppCompatActivity {
 
         // Set up on organizer click listener
         Button organizerButton = findViewById(R.id.organizerButton);
+        organizerButton.setVisibility(View.VISIBLE);
         if (!organizerButton.hasOnClickListeners()) {
             organizerButton.setOnClickListener(v -> {
                 if (user.isOrganizer()) {
@@ -84,10 +87,11 @@ public class SelectRoleActivity extends AppCompatActivity {
                 }
             });
         }
+        Log.e("TEST", "view initialized");
     }
 
-    public void hideAdminButton() {
+    public void showAdminButton() {
         Button adminButton = findViewById(R.id.adminButton);
-        adminButton.setVisibility(View.GONE);
+        adminButton.setVisibility(View.VISIBLE);
     }
 }

--- a/LuckyDragon/app/src/main/java/com/example/luckydragon/SelectRoleView.java
+++ b/LuckyDragon/app/src/main/java/com/example/luckydragon/SelectRoleView.java
@@ -29,8 +29,8 @@ public class SelectRoleView extends Observer {
             selectRoleActivity.initializeView();
         }
 
-        if (!getObservable().isAdmin()) {
-            selectRoleActivity.hideAdminButton();
+        if (getObservable().isAdmin()) {
+            selectRoleActivity.showAdminButton();
         }
     }
 }

--- a/LuckyDragon/app/src/main/java/com/example/luckydragon/User.java
+++ b/LuckyDragon/app/src/main/java/com/example/luckydragon/User.java
@@ -20,7 +20,7 @@ import java.util.Map;
  *   - This is only a basic implementation. Additional functionality should be added as needed.
  *   - Email and phone number may be optional. Additional constructors should be defined for these cases.
  */
-public class User extends Observable implements Serializable {
+public class User extends Observable {
     private FirebaseFirestore db = FirebaseFirestore.getInstance();
 
     private String deviceId;

--- a/LuckyDragon/app/src/main/java/com/example/luckydragon/User.java
+++ b/LuckyDragon/app/src/main/java/com/example/luckydragon/User.java
@@ -215,4 +215,8 @@ public class User extends Observable implements Serializable {
     public Boolean isLoaded() {
         return isLoaded;
     }
+
+    public void setIsLoaded(Boolean newIsLoaded) {
+        isLoaded = newIsLoaded;
+    }
 }

--- a/LuckyDragon/app/src/main/res/layout/select_role_page.xml
+++ b/LuckyDragon/app/src/main/res/layout/select_role_page.xml
@@ -12,6 +12,7 @@
         android:text="Entrant"
         android:padding="15dp"
         android:textSize="24sp"
+        android:visibility="gone"
         style="@style/Widget.MaterialComponents.Button.OutlinedButton"
         />
 
@@ -22,6 +23,7 @@
         android:text="Organizer"
         android:padding="15dp"
         android:textSize="24sp"
+        android:visibility="gone"
         style="@style/Widget.MaterialComponents.Button.OutlinedButton"
         />
 
@@ -32,6 +34,7 @@
         android:text="Administrator"
         android:padding="15dp"
         android:textSize="24sp"
+        android:visibility="gone"
         style="@style/Widget.MaterialComponents.Button.OutlinedButton"
         />
 


### PR DESCRIPTION
## Changes
- Select role buttons have visibility GONE until set to VISIBLE in initializeView(). This way the buttons don't show until they are initialized with on click listeners. If user is not an admin, the admin button won't pop up for a second before disappearing.
- Writes tests for SelectRoleActivity. See SelectRoleActivityTest to see how to formulate UI tests. There are some notes in the class comment.