### PR TITLE
Adds an option to enable geolocation for an event, and displays warning for entrants when signing up for an event with geolocation

### DIFF
--- a/LuckyDragon/app/src/main/java/com/example/luckydragon/AddEventController.java
+++ b/LuckyDragon/app/src/main/java/com/example/luckydragon/AddEventController.java
@@ -3,6 +3,7 @@ package com.example.luckydragon;
 import android.view.View;
 import android.widget.EditText;
 
+import com.google.android.material.switchmaterial.SwitchMaterial;
 import com.google.android.material.timepicker.MaterialTimePicker;
 
 import java.time.Instant;
@@ -64,4 +65,7 @@ public class AddEventController extends Controller {
         getObservable().setDate(date);
     }
 
+    public void extractHasGeolocation(SwitchMaterial toggle) {
+        getObservable().setHasGeolocation(toggle.isEnabled());
+    }
 }

--- a/LuckyDragon/app/src/main/java/com/example/luckydragon/AddEventDialogFragment.java
+++ b/LuckyDragon/app/src/main/java/com/example/luckydragon/AddEventDialogFragment.java
@@ -21,6 +21,7 @@ import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 import com.google.android.material.datepicker.MaterialDatePicker;
 import com.google.android.material.datepicker.MaterialPickerOnPositiveButtonClickListener;
+import com.google.android.material.switchmaterial.SwitchMaterial;
 import com.google.android.material.textfield.TextInputEditText;
 import com.google.android.material.textview.MaterialTextView;
 import com.google.android.material.timepicker.MaterialTimePicker;
@@ -86,11 +87,13 @@ public class AddEventDialogFragment extends DialogFragment {
                     TextInputEditText eventNameEditText = dialogView.findViewById(R.id.eventNameEditText);
                     TextInputEditText waitlistLimitEditText = dialogView.findViewById(R.id.waitlistLimitEditText);
                     TextInputEditText attendeeLimitEditText = dialogView.findViewById(R.id.attendeeLimitEditText);
+                    SwitchMaterial hasGeolocationSwitch = dialogView.findViewById(R.id.geolocation_switch);
 
                     // extract event (auto added to db)
                     controller.extractName(eventNameEditText);
                     controller.extractWaitLimit(waitlistLimitEditText);
                     controller.extractAttendeeLimit(attendeeLimitEditText);
+                    controller.extractHasGeolocation(hasGeolocationSwitch);
 
                     // TODO: Make view reply if event with same info has been created upon save attempt
 

--- a/LuckyDragon/app/src/main/java/com/example/luckydragon/EntrantProfileFragment.java
+++ b/LuckyDragon/app/src/main/java/com/example/luckydragon/EntrantProfileFragment.java
@@ -29,7 +29,7 @@ public class EntrantProfileFragment extends Fragment {
 
             // This is for testing without scanning QR Code:
             Intent intent = new Intent(getActivity(), EventActivity.class);
-            String eventId = "xW99IRUQi2EXMa9wFNWJ";
+            String eventId = "LWwd9mqQu0QNxhek5okF";
             intent.putExtra("eventID", eventId);
             // Reference: https://stackoverflow.com/questions/60503568/best-possible-way-to-get-device-id-in-android
             String deviceID = Settings.Secure.getString(getActivity().getContentResolver(), Settings.Secure.ANDROID_ID);

--- a/LuckyDragon/app/src/main/java/com/example/luckydragon/Event.java
+++ b/LuckyDragon/app/src/main/java/com/example/luckydragon/Event.java
@@ -205,7 +205,6 @@ public class Event extends Observable {
                 waitListLimit = (int) (long) eventData.get("waitListLimit");
                 attendeeLimit = (int) (long) eventData.get("attendeeLimit");
                 hasGeolocation = (Boolean) eventData.get("hasGeolocation");
-                System.out.println(hasGeolocation);
                 date = (String) eventData.get("date");
                 time = new Time((int) (long) eventData.get("hours"), (int) (long) eventData.get("minutes"));
 //                TODO: Decode qrHash

--- a/LuckyDragon/app/src/main/java/com/example/luckydragon/Event.java
+++ b/LuckyDragon/app/src/main/java/com/example/luckydragon/Event.java
@@ -71,6 +71,7 @@ public class Event extends Observable {
     private String facility = "";
     private Integer waitListLimit = -1;
     private Integer attendeeLimit = -1;
+    private Boolean hasGeolocation = false;
     private String date = LocalDate.now().toString();
     private Time time = new Time(0, 0);
     private BitMatrix qrHash;
@@ -162,6 +163,7 @@ public class Event extends Observable {
         eventData.put("facility", facility);
         eventData.put("waitListLimit", waitListLimit);
         eventData.put("attendeeLimit", attendeeLimit);
+        eventData.put("hasGeolocation", hasGeolocation);
         eventData.put("date", date);
         eventData.put("hours", time.hours);
         eventData.put("minutes", time.minutes);
@@ -202,6 +204,8 @@ public class Event extends Observable {
                 facility = (String) eventData.get("facility");
                 waitListLimit = (int) (long) eventData.get("waitListLimit");
                 attendeeLimit = (int) (long) eventData.get("attendeeLimit");
+                hasGeolocation = (Boolean) eventData.get("hasGeolocation");
+                System.out.println(hasGeolocation);
                 date = (String) eventData.get("date");
                 time = new Time((int) (long) eventData.get("hours"), (int) (long) eventData.get("minutes"));
 //                TODO: Decode qrHash
@@ -405,6 +409,8 @@ public class Event extends Observable {
         return attendeeList.size();
     }
 
+    public boolean hasGeolocation() { return hasGeolocation; }
+
     public boolean onWaitList(String deviceId) {
         return waitList.contains(deviceId);
     }
@@ -467,6 +473,11 @@ public class Event extends Observable {
 
     public void setDate(String date) {
         this.date = date;
+        notifyObservers();
+    }
+
+    public void setHasGeolocation(Boolean hasGeolocation) {
+        this.hasGeolocation = hasGeolocation;
         notifyObservers();
     }
 }

--- a/LuckyDragon/app/src/main/java/com/example/luckydragon/EventActivity.java
+++ b/LuckyDragon/app/src/main/java/com/example/luckydragon/EventActivity.java
@@ -7,7 +7,6 @@ import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;

--- a/LuckyDragon/app/src/main/java/com/example/luckydragon/EventActivity.java
+++ b/LuckyDragon/app/src/main/java/com/example/luckydragon/EventActivity.java
@@ -7,6 +7,7 @@ import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;

--- a/LuckyDragon/app/src/main/java/com/example/luckydragon/EventView.java
+++ b/LuckyDragon/app/src/main/java/com/example/luckydragon/EventView.java
@@ -3,11 +3,13 @@ package com.example.luckydragon;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
+import android.widget.Toast;
 
 public class EventView extends Observer {
     private TextView eventNameView;
     private TextView facilityNameView;
     private TextView dateAndTimeView;
+    private TextView geolocationWarningView;
     private TextView waitlistSpotsView;
     private TextView attendeeSpotsView;
     private TextView currentlyJoinedView;
@@ -28,6 +30,7 @@ public class EventView extends Observer {
         eventNameView = eventActivity.findViewById(R.id.eventName);
         facilityNameView = eventActivity.findViewById(R.id.facilityName);
         dateAndTimeView = eventActivity.findViewById(R.id.dateAndTime);
+        geolocationWarningView = eventActivity.findViewById(R.id.geolcationWarning);
         waitlistSpotsView = eventActivity.findViewById(R.id.waitlistSpots);
         attendeeSpotsView = eventActivity.findViewById(R.id.attendeeSpots);
         currentlyJoinedView = eventActivity.findViewById(R.id.currentlyJoined);
@@ -53,6 +56,13 @@ public class EventView extends Observer {
         eventNameView.setText(getObservable().getName());
         facilityNameView.setText(getObservable().getFacility());
         dateAndTimeView.setText(getObservable().getDateAndTime());
+
+        // show warning if event requires geolocation (US 01.08.01)
+        if (getObservable().hasGeolocation()) {
+            geolocationWarningView.setVisibility(View.VISIBLE);
+        } else {
+            geolocationWarningView.setVisibility(View.INVISIBLE);
+        }
 
         // set list limit counts
         if (getObservable().getWaitListSpots() == -1) {

--- a/LuckyDragon/app/src/main/java/com/example/luckydragon/EventView.java
+++ b/LuckyDragon/app/src/main/java/com/example/luckydragon/EventView.java
@@ -3,7 +3,6 @@ package com.example.luckydragon;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
-import android.widget.Toast;
 
 public class EventView extends Observer {
     private TextView eventNameView;

--- a/LuckyDragon/app/src/main/res/layout/activity_event.xml
+++ b/LuckyDragon/app/src/main/res/layout/activity_event.xml
@@ -32,6 +32,13 @@
             android:layout_height="wrap_content"
             android:textSize="25sp"
             android:text="@string/date_time"/>
+        <TextView
+            android:id="@+id/geolcationWarning"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="20sp"
+            android:textStyle="bold|italic"
+            android:text="@string/geolocation_warning"/>
     </LinearLayout>
     <LinearLayout
         android:layout_width="match_parent"

--- a/LuckyDragon/app/src/main/res/layout/dialog_create_event_material.xml
+++ b/LuckyDragon/app/src/main/res/layout/dialog_create_event_material.xml
@@ -116,6 +116,17 @@
         android:textSize="16sp"
         android:layout_marginTop="10dp"
         />
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/geolocation_switch"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:text="Geolocation"
+        android:background="@drawable/frame"
+        android:paddingStart="15dp"
+        android:paddingVertical="17.5dp"
+        android:textSize="16sp"
+        android:layout_marginTop="10dp"
+        />
 
     <LinearLayout
         android:layout_width="fill_parent"

--- a/LuckyDragon/app/src/main/res/values/strings.xml
+++ b/LuckyDragon/app/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="waitlist_spots">Waitlist Spots:</string>
     <string name="waitlist_status">Waitlist status</string>
     <string name="date_time">Date -- Time</string>
+    <string name="geolocation_warning">Requires geolocation!</string>
     <string name="facility_name">Facility Name</string>
     <string name="currently_joined">Currently Joined:</string>
     <string name="attendee_spots">Attendee Spots:</string>


### PR DESCRIPTION
This PR adds an option to have geolocation for an event. It also shows a warning to entrants when signing up for an event with geolocation.

This covers the 2 user stories:
> US 02.02.03 As an organizer I want to enable or disable the geolocation requirement for my event.
> US 01.08.01 As an entrant, I want to be warned before joining a waiting list that requires geolocation.