### PR TITLE
Global app reset state

### DIFF
--- a/LuckyDragon/.idea/androidTestResultsUserPreferences.xml
+++ b/LuckyDragon/.idea/androidTestResultsUserPreferences.xml
@@ -55,6 +55,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-1234155906">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Medium_Phone_API_35" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="-1164133002">
           <value>
             <AndroidTestResultsTableState>
@@ -101,6 +114,19 @@
                 <map>
                   <entry key="Duration" value="90" />
                   <entry key="Pixel_8_API_35" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="-575607272">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Medium_Phone_API_35" value="120" />
                   <entry key="Tests" value="360" />
                 </map>
               </option>

--- a/LuckyDragon/.idea/deploymentTargetSelector.xml
+++ b/LuckyDragon/.idea/deploymentTargetSelector.xml
@@ -13,19 +13,13 @@
         </DropdownSelection>
         <DialogSelection />
       </SelectionState>
-      <SelectionState runConfigName="testEntrantEdit()">
+      <SelectionState runConfigName="testEnableEventGeolocation()">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+      <SelectionState runConfigName="testEventGeolocationWarning()">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
       <SelectionState runConfigName="testJoinWaitlist()">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
-      <SelectionState runConfigName="EntrantNotInEventTest">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
-      <SelectionState runConfigName="EntrantInvitedEventTest">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
-      <SelectionState runConfigName="testAcceptInvite()">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
     </selectionStates>

--- a/LuckyDragon/app/src/androidTest/java/com/example/luckydragon/MockedDb.java
+++ b/LuckyDragon/app/src/androidTest/java/com/example/luckydragon/MockedDb.java
@@ -129,8 +129,7 @@ public abstract class MockedDb {
         // Reset global app state
         final Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
         GlobalApp globalApp = (GlobalApp) targetContext.getApplicationContext();
-        globalApp.setDb(null);
-        globalApp.setUser(null);
+        globalApp.resetState();
 
         Intents.release();
     }

--- a/LuckyDragon/app/src/androidTest/java/com/example/luckydragon/userStoryTest/EventGeolocationWarning.java
+++ b/LuckyDragon/app/src/androidTest/java/com/example/luckydragon/userStoryTest/EventGeolocationWarning.java
@@ -50,12 +50,12 @@ public class EventGeolocationWarning extends MockedDb {
         eventData.put("name", "C301 Standup");
         eventData.put("organizerDeviceId", "mockOrgId");
         eventData.put("facility", "UofA");
-        eventData.put("waitListLimit", 10);
-        eventData.put("attendeeLimit", 10);
+        eventData.put("waitListLimit", new Long(10));
+        eventData.put("attendeeLimit", new Long(10));
         eventData.put("hasGeolocation", true);
         eventData.put("date", LocalDate.now().toString());
-        eventData.put("hours", 10);
-        eventData.put("minutes", 30);
+        eventData.put("hours", new Long(10));
+        eventData.put("minutes", new Long(30));
         eventData.put("hashedQR", "Fake QR");
         eventData.put("waitList", new ArrayList<>());
         eventData.put("inviteeList", new ArrayList<>());

--- a/LuckyDragon/app/src/androidTest/java/com/example/luckydragon/userStoryTest/EventGeolocationWarning.java
+++ b/LuckyDragon/app/src/androidTest/java/com/example/luckydragon/userStoryTest/EventGeolocationWarning.java
@@ -1,0 +1,91 @@
+package com.example.luckydragon.userStoryTest;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.content.Intent;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import com.example.luckydragon.Event;
+import com.example.luckydragon.EventActivity;
+import com.example.luckydragon.GlobalApp;
+import com.example.luckydragon.MockedDb;
+import com.example.luckydragon.R;
+
+import org.junit.Test;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+public class EventGeolocationWarning extends MockedDb {
+    @Override
+    protected HashMap<String, Object> getMockData() {
+        // Define test user
+        HashMap<String, Object> testUserData = new HashMap<>();
+        // Personal info
+        testUserData.put("name", "John Doe");
+        testUserData.put("email", "jdoe@ualberta.ca");
+        testUserData.put("phoneNumber", "780-831-3291");
+        // Roles
+        testUserData.put("isEntrant", true);
+        testUserData.put("isOrganizer", true);
+        testUserData.put("isAdmin", false);
+        // Facility
+        testUserData.put("facility", "The Sports Centre");
+
+        return testUserData;
+    }
+
+    @Override
+    protected HashMap<String, Object> getMockEventData() {
+        HashMap<String, Object> eventData = new HashMap<>();
+        eventData.put("name", "C301 Standup");
+        eventData.put("organizerDeviceId", "mockOrgId");
+        eventData.put("facility", "UofA");
+        eventData.put("waitListLimit", 10);
+        eventData.put("attendeeLimit", 10);
+        eventData.put("hasGeolocation", true);
+        eventData.put("date", LocalDate.now().toString());
+        eventData.put("hours", 10);
+        eventData.put("minutes", 30);
+        eventData.put("hashedQR", "Fake QR");
+        eventData.put("waitList", new ArrayList<>());
+        eventData.put("inviteeList", new ArrayList<>());
+        eventData.put("attendeeList", new ArrayList<>());
+        eventData.put("cancelledList", new ArrayList<>());
+
+        return eventData;
+    }
+
+    /**
+     * USER STORY TEST
+     * > US 01.08.01 Entrant - be warned before joining a waitlist that requires geolocation
+     * Launch activity directly on event activity
+     * Event has geolocation enabled
+     * Text is displayed warning the user that this event has geolocation enabled
+     */
+    @Test
+    public void testEventGeolocationWarning() {
+        final Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        GlobalApp globalApp = (GlobalApp) targetContext.getApplicationContext();
+        globalApp.setDb(mockFirestore);
+        globalApp.setDeviceId("fakeDeviceId");
+
+
+        // Launch event activity directly
+        final Intent intent = new Intent(targetContext, EventActivity.class);
+        intent.putExtra("eventID", "fakeEventId");
+        try (final ActivityScenario<EventActivity> scenario = ActivityScenario.launch(intent)) {
+            // check if geolocation warning is shown
+            onView(withId(R.id.geolcationWarning)).check(matches(isDisplayed()));
+        }
+    }
+}

--- a/LuckyDragon/app/src/main/java/com/example/luckydragon/Event.java
+++ b/LuckyDragon/app/src/main/java/com/example/luckydragon/Event.java
@@ -216,10 +216,10 @@ public class Event extends Observable implements Serializable {
             facility = (String) eventData.get("facility");
         }
         if (nonNull(eventData.get("waitListLimit"))) {
-            waitListLimit = ((Long) eventData.get("waitListLimit")).intValue();
+            waitListLimit = ((Number) eventData.get("waitListLimit")).intValue();
         }
         if (nonNull(eventData.get("attendeeLimit"))) {
-            attendeeLimit = ((Long) eventData.get("attendeeLimit")).intValue();
+            attendeeLimit = ((Number) eventData.get("attendeeLimit")).intValue();
         }
         if (nonNull(eventData.get("hasGeolocation"))) {
             hasGeolocation = (boolean) eventData.get("hasGeolocation");
@@ -235,8 +235,8 @@ public class Event extends Observable implements Serializable {
 //        hasGeolocation = eventData.get("hasGeolocation") != null ? (Boolean) eventData.get("hasGeolocation") : null;
 //        date = eventData.get("date") != null ? (String) eventData.get("date") : null;
 
-        int hours = eventData.get("hours") != null ? ((Long) eventData.get("hours")).intValue() : null;
-        int minutes = eventData.get("minutes") != null ? ((Long) eventData.get("minutes")).intValue() : null;
+        int hours = eventData.get("hours") != null ? ((Number) eventData.get("hours")).intValue() : null;
+        int minutes = eventData.get("minutes") != null ? ((Number) eventData.get("minutes")).intValue() : null;
         time = new Time(hours, minutes);
 
 

--- a/LuckyDragon/app/src/main/java/com/example/luckydragon/Event.java
+++ b/LuckyDragon/app/src/main/java/com/example/luckydragon/Event.java
@@ -216,10 +216,10 @@ public class Event extends Observable implements Serializable {
             facility = (String) eventData.get("facility");
         }
         if (nonNull(eventData.get("waitListLimit"))) {
-            waitListLimit = ((Number) eventData.get("waitListLimit")).intValue();
+            waitListLimit = ((Long) eventData.get("waitListLimit")).intValue();
         }
         if (nonNull(eventData.get("attendeeLimit"))) {
-            attendeeLimit = ((Number) eventData.get("attendeeLimit")).intValue();
+            attendeeLimit = ((Long) eventData.get("attendeeLimit")).intValue();
         }
         if (nonNull(eventData.get("hasGeolocation"))) {
             hasGeolocation = (boolean) eventData.get("hasGeolocation");
@@ -235,8 +235,8 @@ public class Event extends Observable implements Serializable {
 //        hasGeolocation = eventData.get("hasGeolocation") != null ? (Boolean) eventData.get("hasGeolocation") : null;
 //        date = eventData.get("date") != null ? (String) eventData.get("date") : null;
 
-        int hours = eventData.get("hours") != null ? ((Number) eventData.get("hours")).intValue() : null;
-        int minutes = eventData.get("minutes") != null ? ((Number) eventData.get("minutes")).intValue() : null;
+        int hours = eventData.get("hours") != null ? ((Long) eventData.get("hours")).intValue() : null;
+        int minutes = eventData.get("minutes") != null ? ((Long) eventData.get("minutes")).intValue() : null;
         time = new Time(hours, minutes);
 
 

--- a/LuckyDragon/app/src/main/java/com/example/luckydragon/GlobalApp.java
+++ b/LuckyDragon/app/src/main/java/com/example/luckydragon/GlobalApp.java
@@ -103,4 +103,14 @@ public class GlobalApp extends Application {
     public void setDeviceId(String deviceId) {
         this.deviceId = deviceId;
     }
+
+    public void resetState() {
+        db = null;
+        user = null;
+        event = null;
+        role = null;
+        users = null;
+        eventList = null;
+        deviceId = null;
+    }
 }


### PR DESCRIPTION
Adds a resetState() method to GlobalApp which is called by tearDown() in MockedDb. This resolves issues where different tests were affecting each other.