### PR TITLE
Add resetState() function to GlobalApp and call it in MockedDb.tearDo…

### DIFF
--- a/LuckyDragon/app/src/androidTest/java/com/example/luckydragon/MockedDb.java
+++ b/LuckyDragon/app/src/androidTest/java/com/example/luckydragon/MockedDb.java
@@ -129,8 +129,7 @@ public abstract class MockedDb {
         // Reset global app state
         final Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
         GlobalApp globalApp = (GlobalApp) targetContext.getApplicationContext();
-        globalApp.setDb(null);
-        globalApp.setUser(null);
+        globalApp.resetState();
 
         Intents.release();
     }

--- a/LuckyDragon/app/src/main/java/com/example/luckydragon/GlobalApp.java
+++ b/LuckyDragon/app/src/main/java/com/example/luckydragon/GlobalApp.java
@@ -103,4 +103,14 @@ public class GlobalApp extends Application {
     public void setDeviceId(String deviceId) {
         this.deviceId = deviceId;
     }
+
+    public void resetState() {
+        db = null;
+        user = null;
+        role = null;
+        event = null;
+        users = null;
+        eventList = null;
+        deviceId = null;
+    }
 }


### PR DESCRIPTION
Add resetState() function to GlobalApp and call it in MockedDb.tearDown(). This fully resets GlobalApp state. It was only partionally reset before, which caused issues with tests affecting each other.