### PR TITLE
Fix bug where organizer event page crashes (fixes #74)

### DIFF
--- a/LuckyDragon/.idea/deploymentTargetSelector.xml
+++ b/LuckyDragon/.idea/deploymentTargetSelector.xml
@@ -13,12 +13,6 @@
         </DropdownSelection>
         <DialogSelection />
       </SelectionState>
-      <SelectionState runConfigName="Tests in 'com.example.luckydragon.userStoryTest'">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
-      <SelectionState runConfigName="testBrowseEvents()">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/LuckyDragon/app/src/main/java/com/example/luckydragon/Fragments/OrganizerEventFragment.java
+++ b/LuckyDragon/app/src/main/java/com/example/luckydragon/Fragments/OrganizerEventFragment.java
@@ -73,4 +73,12 @@ public class OrganizerEventFragment extends Fragment {
         }
         waitlistCapacityTextView.setText(String.format("Capacity: %s", waitlistLimit));
     }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+
+        // the view associated with this fragment must stop observing when the fragment is destroyed
+        organizerEventView.stopObserving();
+    }
 }


### PR DESCRIPTION
Fixes #74 by just having the View stop observing the Fragment once the Fragment has been closed.