### PR TITLE
Sample attendees

### DIFF
--- a/LuckyDragon/.idea/androidTestResultsUserPreferences.xml
+++ b/LuckyDragon/.idea/androidTestResultsUserPreferences.xml
@@ -42,6 +42,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-1346510998">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_8a_API_35" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="-1289085829">
           <value>
             <AndroidTestResultsTableState>

--- a/LuckyDragon/.idea/deploymentTargetSelector.xml
+++ b/LuckyDragon/.idea/deploymentTargetSelector.xml
@@ -16,13 +16,7 @@
       <SelectionState runConfigName="Tests in 'com.example.luckydragon.userStoryTest'">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
-      <SelectionState runConfigName="EntrantInvitedEventDenyTest">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
-      <SelectionState runConfigName="OrganizerViewMapTest">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
-      <SelectionState runConfigName="Tests in 'com.example.luckydragon'">
+      <SelectionState runConfigName="SampleInviteesTest">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
     </selectionStates>

--- a/LuckyDragon/app/src/androidTest/java/com/example/luckydragon/userStoryTest/SampleInviteesTest.java
+++ b/LuckyDragon/app/src/androidTest/java/com/example/luckydragon/userStoryTest/SampleInviteesTest.java
@@ -1,0 +1,369 @@
+package com.example.luckydragon.userStoryTest;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.espresso.intent.Intents;
+import androidx.test.espresso.matcher.ViewMatchers;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import com.example.luckydragon.Activities.SelectRoleActivity;
+import com.example.luckydragon.GlobalApp;
+import com.example.luckydragon.Models.Event;
+import com.example.luckydragon.R;
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.OnFailureListener;
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.DocumentReference;
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.Query;
+import com.google.firebase.firestore.QueryDocumentSnapshot;
+import com.google.firebase.firestore.QuerySnapshot;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Contains tests for US 02.02.01.
+ * As an organizer I want to view the list of entrants who joined my event waiting list.
+ */
+public class SampleInviteesTest {
+    @Mock
+    private FirebaseFirestore mockFirestore;
+    // User mocks
+    @Mock
+    private CollectionReference mockUsersCollection;
+    @Mock
+    private DocumentReference mockUserDocument;
+    @Mock
+    private DocumentSnapshot mockUserDocumentSnapshot;
+    @Mock
+    private Task<DocumentSnapshot> mockUserTask;
+    @Mock
+    private Task<Void> mockVoidTask;
+
+    // Waitlist user mocks
+    @Mock
+    private DocumentReference mockWaitlistEntrant1Document;
+    @Mock
+    private Task<DocumentSnapshot> mockWaitlistEntrant1Task;
+    @Mock
+    private DocumentSnapshot mockWaitlistEntrant1DocumentSnapshot;
+    @Mock
+    private DocumentReference mockWaitlistEntrant2Document;
+    @Mock
+    private Task<DocumentSnapshot> mockWaitlistEntrant2Task;
+    @Mock
+    private DocumentSnapshot mockWaitlistEntrant2DocumentSnapshot;
+
+    // Event mocks
+    @Mock
+    private CollectionReference mockEventsCollection;
+    @Mock
+    private DocumentReference mockEventDocument;
+    @Mock
+    private Query mockEventQuery;
+    @Mock
+    private Task<QuerySnapshot> mockEventQueryTask;
+    @Mock
+    private QuerySnapshot mockEventQuerySnapshot;
+    @Mock
+    private List<DocumentSnapshot> mockEventDocumentSnapshotList;
+    @Mock
+    private QueryDocumentSnapshot mockEventQueryDocumentSnapshot1;
+    @Mock
+    private QueryDocumentSnapshot mockEventQueryDocumentSnapshot2;
+
+    @Mock
+    private DocumentReference mockEventDocument1;
+    @Mock
+    private DocumentReference mockEventDocument2;
+    @Mock
+    private Task<DocumentSnapshot> mockEventTask1;
+    @Mock
+    private Task<DocumentSnapshot> mockEventTask2;
+    @Mock
+    private DocumentSnapshot mockEventDocumentSnapshot1;
+    @Mock
+    private DocumentSnapshot mockEventDocumentSnapshot2;
+
+    // Event Data
+    private List<Map<String, Object>> eventData = new ArrayList<>();
+
+    private HashMap<String, Object> getMockUserData() {
+        // Define test user
+        HashMap<String, Object> testUserData = new HashMap<>();
+        // Personal info
+        testUserData.put("name", "John Doe");
+        testUserData.put("email", "jdoe@ualberta.ca");
+        testUserData.put("phoneNumber", "780-831-3291");
+        // Roles
+        testUserData.put("isEntrant", true);
+        testUserData.put("isOrganizer", true);
+        testUserData.put("isAdmin", false);
+        // Facility
+        testUserData.put("facility", "The Sports Centre");
+
+        return testUserData;
+    }
+
+    private HashMap<String, Object> getMockWaitlistUser1() {
+        // Define test user
+        HashMap<String, Object> testUserData = new HashMap<>();
+        // Personal info
+        testUserData.put("name", "Tony Sun");
+        testUserData.put("email", "tonysun@ualberta.ca");
+        testUserData.put("phoneNumber", "780-831-3291");
+        // Roles
+        testUserData.put("isEntrant", true);
+        testUserData.put("isOrganizer", false);
+        testUserData.put("isAdmin", false);
+
+        return testUserData;
+    }
+
+    private HashMap<String, Object> getMockWaitlistUser2() {
+        // Define test user
+        HashMap<String, Object> testUserData = new HashMap<>();
+        // Personal info
+        testUserData.put("name", "Matthew Fischer");
+        testUserData.put("email", "matthewfischer@ualberta.ca");
+        testUserData.put("phoneNumber", "780-831-3291");
+        // Roles
+        testUserData.put("isEntrant", true);
+        testUserData.put("isOrganizer", false);
+        testUserData.put("isAdmin", false);
+
+        return testUserData;
+    }
+
+    @Before
+    public void setup() {
+        Intents.init();
+        openMocks(this);
+
+        // Initialize event data
+        HashMap<String, Object> eventData1 = new HashMap<>();
+        eventData1.put("name", "Piano Lesson");
+        eventData1.put("organizerDeviceId", "abcd1234");
+        eventData1.put("facility", "Piano Place");
+        eventData1.put("waitlistLimit", new Long(10));
+        eventData1.put("attendeeLimit", new Long(2));
+        eventData1.put("date", "2025-01-15");
+        eventData1.put("hours", new Long(18));
+        eventData1.put("minutes", new Long(15));
+        eventData1.put("waitList", List.of("ts123", "mf456"));
+        eventData1.put("createdTimeMillis", 1731294000000L); // event created Nov 10 2024 8:00:00 PM
+        eventData.add(eventData1);
+
+        HashMap<String, Object> eventData2 = new HashMap<>();
+        eventData2.put("name", "Group Piano Lesson");
+        eventData2.put("organizerDeviceId", "abcd1234");
+        eventData2.put("facility", "Piano Place");
+        eventData2.put("waitlistLimit", new Long(20));
+        eventData2.put("attendeeLimit", new Long(5));
+        eventData2.put("date", "2025-01-16");
+        eventData2.put("hours", new Long(18));
+        eventData2.put("minutes", new Long(15));
+        eventData.add(eventData2);
+
+        // Set up user mocking for main user
+        when(mockFirestore.collection("users")).thenReturn(mockUsersCollection);
+        when(mockUsersCollection.document(anyString())).thenReturn(mockUserDocument);
+        when(mockUserDocument.get()).thenReturn(mockUserTask);
+        when(mockUserDocument.set(any(Map.class))).thenReturn(mockVoidTask);
+        when(mockUserTask.addOnFailureListener(any(OnFailureListener.class))).thenReturn(mockUserTask);
+        doAnswer(invocation -> {
+            OnSuccessListener<DocumentSnapshot> listener = invocation.getArgument(0);
+            listener.onSuccess(mockUserDocumentSnapshot);
+            return mockUserTask;
+        }).when(mockUserTask).addOnSuccessListener(any(OnSuccessListener.class));
+        when(mockUserDocumentSnapshot.getData()).thenReturn(getMockUserData());
+
+        // Set up mockito mocking for waitlist user 1
+        when(mockUsersCollection.document("ts123")).thenReturn(mockWaitlistEntrant1Document);
+        when(mockWaitlistEntrant1Document.get()).thenReturn(mockWaitlistEntrant1Task);
+        when(mockWaitlistEntrant1Document.set(any(Map.class))).thenReturn(mockVoidTask);
+        when(mockWaitlistEntrant1Task.addOnFailureListener(any(OnFailureListener.class))).thenReturn(mockWaitlistEntrant1Task);
+        doAnswer(invocation -> {
+            OnSuccessListener<DocumentSnapshot> listener = invocation.getArgument(0);
+            listener.onSuccess(mockWaitlistEntrant1DocumentSnapshot);
+            return mockWaitlistEntrant1Task;
+        }).when(mockWaitlistEntrant1Task).addOnSuccessListener(any(OnSuccessListener.class));
+        when(mockWaitlistEntrant1DocumentSnapshot.getData()).thenReturn(getMockWaitlistUser1());
+
+        // Set up mockito mocking for waitlist user 2
+        when(mockUsersCollection.document("mf456")).thenReturn(mockWaitlistEntrant2Document);
+        when(mockWaitlistEntrant2Document.get()).thenReturn(mockWaitlistEntrant2Task);
+        when(mockWaitlistEntrant2Document.set(any(Map.class))).thenReturn(mockVoidTask);
+        when(mockWaitlistEntrant2Task.addOnFailureListener(any(OnFailureListener.class))).thenReturn(mockWaitlistEntrant2Task);
+        doAnswer(invocation -> {
+            OnSuccessListener<DocumentSnapshot> listener = invocation.getArgument(0);
+            listener.onSuccess(mockWaitlistEntrant2DocumentSnapshot);
+            return mockWaitlistEntrant2Task;
+        }).when(mockWaitlistEntrant2Task).addOnSuccessListener(any(OnSuccessListener.class));
+        when(mockWaitlistEntrant2DocumentSnapshot.getData()).thenReturn(getMockWaitlistUser2());
+
+        // Set up event mocking
+        when(mockFirestore.collection("events")).thenReturn(mockEventsCollection);
+        when(mockEventsCollection.whereEqualTo(anyString(), anyString())).thenReturn(mockEventQuery);
+        when(mockEventQuery.get()).thenReturn(mockEventQueryTask);
+        when(mockEventQueryTask.isSuccessful()).thenReturn(true);
+        when(mockEventQueryTask.getResult()).thenReturn(mockEventQuerySnapshot);
+        when(mockEventQuerySnapshot.size()).thenReturn(2);
+        when(mockEventQuerySnapshot.getDocuments()).thenReturn(mockEventDocumentSnapshotList);
+        when(mockEventDocumentSnapshotList.get(anyInt())).thenAnswer((invocation) -> {
+            int index = invocation.getArgument(0);
+            if(index == 0) return mockEventQueryDocumentSnapshot1;
+            else return mockEventQueryDocumentSnapshot2;
+        });
+        when(mockEventQueryDocumentSnapshot1.getId()).thenReturn(String.valueOf(0));
+        when(mockEventQueryDocumentSnapshot2.getId()).thenReturn(String.valueOf(1));
+        when(mockEventQueryDocumentSnapshot1.getData()).thenReturn(eventData.get(0));
+        when(mockEventQueryDocumentSnapshot2.getData()).thenReturn(eventData.get(1));
+        when(mockEventQueryTask.addOnCompleteListener(any()))
+                .thenAnswer((invocation) -> {
+                    OnCompleteListener<QuerySnapshot> listener = invocation.getArgument(0);
+                    listener.onComplete(mockEventQueryTask);
+
+                    return null;
+                });
+        // We don't want to save anything to the database, so we mock the methods that save an event to the db to do nothing
+        // We also mock getId() to return "mockEventID" instead of going to the database for an id
+        when(mockFirestore.collection("events")).thenReturn(mockEventsCollection);
+        when(mockEventsCollection.document()).thenReturn(mockEventDocument);
+        when(mockEventDocument.getId()).thenReturn("mockEventID");
+
+        when(mockEventsCollection.document("0")).thenReturn(mockEventDocument1);
+        when(mockEventDocument1.get()).thenReturn(mockEventTask1);
+        when(mockEventDocument1.set(anyMap())).thenReturn(mockVoidTask);
+        when(mockEventTask1.addOnCompleteListener(any())).thenAnswer((invocation) -> {
+            OnCompleteListener<DocumentSnapshot> listener = invocation.getArgument(0);
+            listener.onComplete(mockEventTask1);
+            return null;
+        });
+        when(mockEventTask1.isSuccessful()).thenReturn(true);
+        when(mockEventTask1.getResult()).thenReturn(mockEventDocumentSnapshot1);
+        when(mockEventDocumentSnapshot1.exists()).thenReturn(true);
+        when(mockEventDocumentSnapshot1.getData()).thenReturn(eventData.get(0));
+
+        when(mockEventsCollection.document("1")).thenReturn(mockEventDocument2);
+        when(mockEventDocument2.get()).thenReturn(mockEventTask2);
+        when(mockEventDocument2.set(anyMap())).thenReturn(mockVoidTask);
+        when(mockEventTask2.addOnCompleteListener(any())).thenAnswer((invocation) -> {
+            OnCompleteListener<DocumentSnapshot> listener = invocation.getArgument(0);
+            listener.onComplete(mockEventTask2);
+            return null;
+        });
+        when(mockEventTask2.isSuccessful()).thenReturn(true);
+        when(mockEventTask2.getResult()).thenReturn(mockEventDocumentSnapshot2);
+        when(mockEventDocumentSnapshot2.exists()).thenReturn(true);
+        when(mockEventDocumentSnapshot2.getData()).thenReturn(eventData.get(1));
+    }
+
+    @After
+    public void tearDown() {
+        // Reset global app state
+        final Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        GlobalApp globalApp = (GlobalApp) targetContext.getApplicationContext();
+        globalApp.resetState();
+
+        Intents.release();
+    }
+
+    /**
+     * USER STORY TEST
+     * US 02.02.01 -- As an organizer I want to view the list of entrants who joined my event waiting list.
+     * User opens app and selects Organizer.
+     * User's events are displayed.
+     * User clicks on one of these events.
+     * User sees the names of the entrants on the waitlist.
+     */
+    @Test
+    public void testSampleInvitees() {
+        final Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        final Intent intent = new Intent(targetContext, SelectRoleActivity.class);
+
+        GlobalApp globalApp = (GlobalApp) targetContext.getApplicationContext();
+        globalApp.setDb(mockFirestore);
+
+        try(final ActivityScenario<SelectRoleActivity> scenario = ActivityScenario.launch(intent)) {
+            // User is not admin, so admin button should not show
+            onView(ViewMatchers.withId(R.id.entrantButton)).check(matches(isDisplayed()));
+            onView(withId(R.id.organizerButton)).check(matches(isDisplayed()));
+            onView(withId(R.id.adminButton)).check(matches(not(isDisplayed())));
+
+            // User clicks "Organizer"
+            onView(withId(R.id.organizerButton)).perform(click());
+
+            // Profile activity should open and organizer profile should be displayed
+            onView(withId(R.id.organizerProfileLayout)).check(matches(isDisplayed()));
+
+            // The organizer's facility is displayed
+            onView(withId(R.id.facilityTextView)).check(matches(withText("The Sports Centre")));
+
+            // The organizer's events should be displayed
+            onView(withText("Piano Lesson")).check(matches(isDisplayed()));
+            onView(withText("Group Piano Lesson")).check(matches(isDisplayed()));
+
+            // Check that users are on the waitlist for "Piano Lesson" event
+            Event event = globalApp.getUser().getOrganizer().getEvents().get(0);
+            assertTrue(event.getWaitList().size() == 2);
+            assertTrue(event.getWaitList().contains("ts123"));
+            assertTrue(event.getWaitList().contains("mf456"));
+
+            // Organizer clicks on "Piano Lesson"
+            onView(withText("Piano Lesson")).perform(click());
+
+            // Event info is displayed
+            onView(withId(R.id.eventNameTextView)).check(matches(withText("Piano Lesson")));
+            onView(withId(R.id.eventFacilityTextView)).check(matches(withText("Piano Place")));
+            onView(withId(R.id.eventDateAndTimeTextView)).check(matches(withText("6:15 PM -- 2025-01-15")));
+
+            // Waitlist capacity is displayed correctly
+            onView(withId(R.id.waitlistCapacityTextView)).check(matches(withText("Capacity: 10")));
+
+            // Check that users are now in inviteeList
+            assertTrue(event.getInviteeList().contains("ts123"));
+            assertTrue(event.getInviteeList().contains("mf456"));
+            assertTrue(event.getWaitList().isEmpty());
+            assertEquals(event.getInviteeList().size(), 2);
+
+            // TODO could check that invited users are displayed -- invitee display isn't implemented yet
+            //onView(withText("Tony Sun")).check(matches(isDisplayed()));
+            //onView(withText("Matthew Fischer")).check(matches(isDisplayed()));
+        }
+    }
+}

--- a/LuckyDragon/app/src/main/java/com/example/luckydragon/Activities/ViewEventActivity.java
+++ b/LuckyDragon/app/src/main/java/com/example/luckydragon/Activities/ViewEventActivity.java
@@ -59,15 +59,6 @@ public class ViewEventActivity extends AppBarActivity {
         event.fetchData(); // get all event data
         viewEventView = new ViewEventView(event, this);
 
-        // Check if invitees need to be sampled
-        if(!event.haveInviteesBeenSelected()) {
-            Long elapsedMs = System.currentTimeMillis() - event.getCreatedTimeMillis();
-            Long delayMs = globalApp.getInviteeSelectionDelay() * 86400000L;
-            if(elapsedMs >= delayMs) {
-                event.selectInviteesFirstTime();
-            }
-        }
-
         // Hide buttons for entrant
         if(globalApp.getRole() == GlobalApp.ROLE.ENTRANT) {
             hideEditButton();
@@ -177,6 +168,21 @@ public class ViewEventActivity extends AppBarActivity {
                         .setReorderingAllowed(true)
                         .replace(R.id.eventFragmentContainer, AdminEventFragment.class, null)
                         .commit();
+            }
+        }
+    }
+
+    /**
+     * Samples attendees if the waitlist period has passed and they have not been sampled yet.
+     */
+    public void sampleAttendeesIfNeccessary() {
+        if(event == null || event.getCreatedTimeMillis() == null) return;
+        GlobalApp globalApp = (GlobalApp) getApplication();
+        if(!event.haveInviteesBeenSelected()) {
+            Long elapsedMs = System.currentTimeMillis() - event.getCreatedTimeMillis();
+            Long delayMs = globalApp.getInviteeSelectionDelay() * 86400000L;
+            if(elapsedMs >= delayMs) {
+                event.selectInviteesFirstTime();
             }
         }
     }

--- a/LuckyDragon/app/src/main/java/com/example/luckydragon/Activities/ViewEventActivity.java
+++ b/LuckyDragon/app/src/main/java/com/example/luckydragon/Activities/ViewEventActivity.java
@@ -59,6 +59,15 @@ public class ViewEventActivity extends AppBarActivity {
         event.fetchData(); // get all event data
         viewEventView = new ViewEventView(event, this);
 
+        // Check if invitees need to be sampled
+        if(!event.haveInviteesBeenSelected()) {
+            Long elapsedMs = System.currentTimeMillis() - event.getCreatedTimeMillis();
+            Long delayMs = globalApp.getInviteeSelectionDelay() * 86400000L;
+            if(elapsedMs >= delayMs) {
+                event.selectInviteesFirstTime();
+            }
+        }
+
         // Hide buttons for entrant
         if(globalApp.getRole() == GlobalApp.ROLE.ENTRANT) {
             hideEditButton();

--- a/LuckyDragon/app/src/main/java/com/example/luckydragon/Fragments/OrganizerEventFragment.java
+++ b/LuckyDragon/app/src/main/java/com/example/luckydragon/Fragments/OrganizerEventFragment.java
@@ -14,6 +14,7 @@ import com.example.luckydragon.GlobalApp;
 import com.example.luckydragon.Models.Event;
 import com.example.luckydragon.R;
 import com.example.luckydragon.Views.OrganizerEventView;
+import com.google.type.DateTime;
 
 /**
  * This is the fragment containing the organizer-specific event info.

--- a/LuckyDragon/app/src/main/java/com/example/luckydragon/GlobalApp.java
+++ b/LuckyDragon/app/src/main/java/com/example/luckydragon/GlobalApp.java
@@ -30,6 +30,8 @@ public class GlobalApp extends Application {
     private Event event;
     private FirebaseFirestore db;
 
+    private Integer inviteeSelectionDelay = 7; // number of days between when an event is created and when invitees are drawn
+
     private UserList users;
     private EventList eventList;
     private String deviceId = null;
@@ -162,4 +164,6 @@ public class GlobalApp extends Application {
     public Event getEventToView() {
         return eventToView;
     }
+
+    public Integer getInviteeSelectionDelay() { return inviteeSelectionDelay; }
 }

--- a/LuckyDragon/app/src/main/java/com/example/luckydragon/Views/ViewEventView.java
+++ b/LuckyDragon/app/src/main/java/com/example/luckydragon/Views/ViewEventView.java
@@ -32,6 +32,7 @@ public class ViewEventView extends Observer {
         viewEventActivity.updateEventFacility();
         viewEventActivity.updateEventDateAndTime();
         viewEventActivity.loadChildFragment();
+        viewEventActivity.sampleAttendeesIfNeccessary();
     }
 
     @Override


### PR DESCRIPTION
Implements US 02.05.02 Organizer - set the system to sample a specified number of attendees to register for the event

Stores the creation time of an event in the database. Once the delay time (currently 7 days) has elapsed, draws the specified number of attendees from the waitlist and moves them to the invitee list.

I just saw on the forum that the delay time should be customizable. Currently it is hardcoded to 7 days. I will add a field to the event creation dialog to allow the organizer to set the delay time (I will do this by our meeting on Wednesday).