### PR TITLE
Tests for notifications

### DIFF
--- a/LuckyDragon/.idea/androidTestResultsUserPreferences.xml
+++ b/LuckyDragon/.idea/androidTestResultsUserPreferences.xml
@@ -47,6 +47,7 @@
             <AndroidTestResultsTableState>
               <option name="preferredColumnWidths">
                 <map>
+                  <entry key="Copy_of_Medium_Phone_API_35" value="120" />
                   <entry key="Duration" value="90" />
                   <entry key="Pixel_8a_API_35" value="120" />
                   <entry key="Tests" value="360" />
@@ -108,6 +109,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-1153634600">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Copy_of_Medium_Phone_API_35" value="120" />
+                  <entry key="Duration" value="90" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="-858013555">
           <value>
             <AndroidTestResultsTableState>
@@ -160,6 +174,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-551077894">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Copy_of_Medium_Phone_API_35" value="120" />
+                  <entry key="Duration" value="90" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="-487972089">
           <value>
             <AndroidTestResultsTableState>
@@ -195,6 +222,19 @@
                   <entry key="Duration" value="90" />
                   <entry key="Pixel_8_Pro_API_35" value="120" />
                   <entry key="Pixel_8a_API_35" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="-358201496">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Copy_of_Medium_Phone_API_35" value="120" />
+                  <entry key="Duration" value="90" />
                   <entry key="Tests" value="360" />
                 </map>
               </option>
@@ -488,6 +528,19 @@
                 <map>
                   <entry key="Duration" value="90" />
                   <entry key="Medium_Phone_API_35" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="1242511557">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Copy_of_Medium_Phone_API_35" value="120" />
+                  <entry key="Duration" value="90" />
                   <entry key="Tests" value="360" />
                 </map>
               </option>

--- a/LuckyDragon/.idea/deploymentTargetSelector.xml
+++ b/LuckyDragon/.idea/deploymentTargetSelector.xml
@@ -13,10 +13,19 @@
         </DropdownSelection>
         <DialogSelection />
       </SelectionState>
-      <SelectionState runConfigName="testCancelledlistDisplayedEventData1()">
+      <SelectionState runConfigName="SampleInviteesTest">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
-      <SelectionState runConfigName="testCancelledlistDisplayedEventData2()">
+      <SelectionState runConfigName="testSampleInvitees() (1)">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+      <SelectionState runConfigName="OrganizerSendNotificationsTest">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+      <SelectionState runConfigName="testSendNotifToWaitlistedEntrants()">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+      <SelectionState runConfigName="testSampleInvitees()">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
     </selectionStates>


### PR DESCRIPTION
This has tests for the notification user stories:

US 02.07.01 As an organizer I want to send notifications to all entrants on the waiting list

US 02.07.02 As an organizer I want to send notifications to all selected entrants

US 02.07.03 As an organizer I want to send a notification to all cancelled entrants

US 02.05.01 As an organizer I want to send a notification to chosen entrants to sign up for events.

US 01.04.01 As an entrant I want to receive notification when chosen from the waiting list (when I "win" the lottery)

US 01.04.02 As an entrant I want to receive notification of not chosen on the app (when I "lose" the lottery)

I test that the notification is received by the NotificationList since there isn't a way to see if the notification appears on screen in testing using the Espresso framework (which we are using)